### PR TITLE
ci:Add semgrep, npm audit to pull request CI runs

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -26,4 +26,11 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run build --if-present
+    - run: npm audit
     - run: npm test
+
+  security-checks:
+    name: "Security Lint Checks"
+    uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@main
+    with:
+      base_branch: "master"


### PR DESCRIPTION
## Summary
- Adds static analysis to pull request CI runs as well as output of `npm audit` to check for outdated node packages. Note that this doesn't get us to baseline for semgrep or npm audit yet.

## Testing Plan
- Ran semgrep and npm audit locally, waiting for a test run here